### PR TITLE
Remove unused grok-sdk submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "KnowledgeBase/GrokAI/grok-sdk"]
-	path = KnowledgeBase/GrokAI/grok-sdk
-	url = https://github.com/xai-org/grok.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# AICommancenter
+
+This repository collects various PowerShell scripts and modules. Some optional resources are hosted in separate repositories.
+
+## Optional Grok SDK
+
+The directory `KnowledgeBase/GrokAI/grok-sdk` previously referenced a Git submodule for the [grok](https://github.com/xai-org/grok) project. It has been removed from the repository to avoid empty directories.
+
+If you need these files, clone the dependency manually:
+
+```bash
+git clone https://github.com/xai-org/grok.git KnowledgeBase/GrokAI/grok-sdk
+```
+
+To update the dependency later, run:
+
+```bash
+cd KnowledgeBase/GrokAI/grok-sdk
+git pull
+```
+


### PR DESCRIPTION
## Summary
- remove broken `grok-sdk` submodule and `.gitmodules`
- add README with instructions for manually cloning and updating the Grok SDK

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_686b6d4424b883309adbfffd0e52142a