### PR TITLE
Improve portability and add headless browser script

### DIFF
--- a/Config/.env.example
+++ b/Config/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-key-here
+GROK_API_KEY=your-grok-key-here

--- a/Profile/Microsoft.PowerShell_profile.ps1
+++ b/Profile/Microsoft.PowerShell_profile.ps1
@@ -1,35 +1,38 @@
 # === PowerShell AI Command Center Profile ===
 
-$env:PSModulePath = "X:\AICommandCenter\PowerShell\Modules;" + $env:PSModulePath
+# Determine repository root relative to this profile
+$profileDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $profileDir '..')
 
-Get-ChildItem -Path "X:\AICommandCenter\PowerShell\Modules" -Directory | ForEach-Object {
+# Update module path and import any modules found under Modules
+$env:PSModulePath = "$repoRoot\Modules;" + $env:PSModulePath
+
+Get-ChildItem -Path "$repoRoot\Modules" -Directory | ForEach-Object {
     Import-Module $_.FullName -ErrorAction SilentlyContinue
 }
 
-. "X:\AICommandCenter\PowerShell\Tools\SessionLogger.ps1"
-. "X:\AICommandCenter\PowerShell\Tools\Ask-OpenAI.ps1"
+# Load environment variables and utilities
+. "$repoRoot\Tools\Load-Env.ps1"
+. "$repoRoot\Tools\SessionLogger.ps1"
+. "$repoRoot\Tools\Ask-OpenAI.ps1"
+. "$repoRoot\Tools\Start-HeadlessBrowser.ps1"
 
-if (Test-Path "X:\AICommandCenter\PowerShell\Tools\Logging\Write-Log.ps1") {
-    . "X:\AICommandCenter\PowerShell\Tools\Logging\Write-Log.ps1"
+if (Test-Path "$repoRoot\Tools\Logging\Write-Log.ps1") {
+    . "$repoRoot\Tools\Logging\Write-Log.ps1"
 }
 
-if (Test-Path "X:\AICommandCenter\PowerShell") {
-    Set-Location "X:\AICommandCenter\PowerShell"
-} elseif (Test-Path "$env:USERPROFILE\Documents") {
-    Set-Location "$env:USERPROFILE\Documents"
-} else {
-    Set-Location "$HOME"
-}
+# Start in the repository root by default
+Set-Location $repoRoot
 
 $realProfile = $PROFILE
 $redirectLoader = @'
 # Redirect profile loader to AI Command Center
-if (Test-Path "X:\\AICommandCenter\\PowerShell\\Profile\\Microsoft.PowerShell_profile.ps1") {
-    . "X:\\AICommandCenter\\PowerShell\\Profile\\Microsoft.PowerShell_profile.ps1"
+if (Test-Path "$repoRoot\\Profile\\Microsoft.PowerShell_profile.ps1") {
+    . "$repoRoot\\Profile\\Microsoft.PowerShell_profile.ps1"
 }
 '@
 
 $redirectLoader | Set-Content -Path $realProfile -Encoding UTF8
 
-Write-Host "`n✅ Boot profile now redirects to: X:\AICommandCenter\PowerShell\Profile\" -ForegroundColor Green
+Write-Host "`n✅ Boot profile now redirects to: $repoRoot\Profile\" -ForegroundColor Green
 

--- a/Profile/Microsoft.PowerShell_profile.txt
+++ b/Profile/Microsoft.PowerShell_profile.txt
@@ -1,35 +1,33 @@
 # === PowerShell AI Command Center Profile ===
 
-$env:PSModulePath = "X:\AICommandCenter\PowerShell\Modules;" + $env:PSModulePath
+$profileDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $profileDir '..')
+$env:PSModulePath = "$repoRoot\Modules;" + $env:PSModulePath
 
-Get-ChildItem -Path "X:\AICommandCenter\PowerShell\Modules" -Directory | ForEach-Object {
+Get-ChildItem -Path "$repoRoot\Modules" -Directory | ForEach-Object {
     Import-Module $_.FullName -ErrorAction SilentlyContinue
 }
 
-. "X:\AICommandCenter\PowerShell\Tools\SessionLogger.ps1"
-. "X:\AICommandCenter\PowerShell\Tools\Ask-OpenAI.ps1"
+. "$repoRoot\Tools\Load-Env.ps1"
+. "$repoRoot\Tools\SessionLogger.ps1"
+. "$repoRoot\Tools\Ask-OpenAI.ps1"
+. "$repoRoot\Tools\Start-HeadlessBrowser.ps1"
 
-if (Test-Path "X:\AICommandCenter\PowerShell\Tools\Logging\Write-Log.ps1") {
-    . "X:\AICommandCenter\PowerShell\Tools\Logging\Write-Log.ps1"
+if (Test-Path "$repoRoot\Tools\Logging\Write-Log.ps1") {
+    . "$repoRoot\Tools\Logging\Write-Log.ps1"
 }
 
-if (Test-Path "X:\AICommandCenter\PowerShell") {
-    Set-Location "X:\AICommandCenter\PowerShell"
-} elseif (Test-Path "$env:USERPROFILE\Documents") {
-    Set-Location "$env:USERPROFILE\Documents"
-} else {
-    Set-Location "$HOME"
-}
+Set-Location $repoRoot
 
 $realProfile = $PROFILE
 $redirectLoader = @'
 # Redirect profile loader to AI Command Center
-if (Test-Path "X:\\AICommandCenter\\PowerShell\\Profile\\Microsoft.PowerShell_profile.ps1") {
-    . "X:\\AICommandCenter\\PowerShell\\Profile\\Microsoft.PowerShell_profile.ps1"
+if (Test-Path "$repoRoot\\Profile\\Microsoft.PowerShell_profile.ps1") {
+    . "$repoRoot\\Profile\\Microsoft.PowerShell_profile.ps1"
 }
 '@
 
 $redirectLoader | Set-Content -Path $realProfile -Encoding UTF8
 
-Write-Host "`n✅ Boot profile now redirects to: X:\AICommandCenter\PowerShell\Profile\" -ForegroundColor Green
+Write-Host "`n✅ Boot profile now redirects to: $repoRoot\Profile\" -ForegroundColor Green
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ This repository collects various PowerShell tools and modules used for working w
    git clone https://github.com/xai-org/grok.git KnowledgeBase/GrokAI/grok-sdk
    ```
 
+## Using the PowerShell profile
+
+The repository includes a profile script at `Profile/Microsoft.PowerShell_profile.ps1`.
+Copy this file to your PowerShell profile path (run `$PROFILE` in PowerShell to see the location) or invoke it manually to automatically load the modules and environment variables on startup.
+
 ## Environment variables
 
-API keys are loaded from a `.env` file. Scripts such as `AgentChatController_20250519_121655.ps1` and `Load-Env.ps1` expect this file at `Config/.env`:
+API keys are loaded from a `.env` file. An example file is provided at `Config/.env.example`. Copy it to `Config/.env` and fill in your keys. Scripts such as `AgentChatController_20250519_121655.ps1` and `Load-Env.ps1` expect this file:
 
 ```
 OPENAI_API_KEY=<your OpenAI key>
@@ -47,6 +52,10 @@ Run `Tools/Load-Env.ps1` to import the variables into the current PowerShell ses
 - **SessionLogger.ps1** – Writes PowerShell version and timestamp to `Logs/SessionLog.csv`:
   ```powershell
   ./Tools/SessionLogger.ps1
+  ```
+- **Start-HeadlessBrowser.ps1** – Launches Chrome or Edge in headless mode:
+  ```powershell
+  ./Tools/Start-HeadlessBrowser.ps1 -Url "https://example.com" -Edge
   ```
 
 ## Optional Grok SDK

--- a/Scan-PowerShellStructure.ps1
+++ b/Scan-PowerShellStructure.ps1
@@ -1,14 +1,16 @@
 # === PowerShell Folder Structure Scan ===
 
-# Ensure Logs directory exists
-$logPath = "X:\AICommandCenter\PowerShell\Logs\PowerShell_TreeMap.txt"
+# Determine repository root and log location
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path $scriptRoot
+$logPath = Join-Path $repoRoot 'Logs/PowerShell_TreeMap.txt'
 $logDir = Split-Path $logPath
 if (-not (Test-Path $logDir)) {
     New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 }
 
-# Collect all paths under PowerShell root
-$structure = Get-ChildItem -Path "X:\AICommandCenter\PowerShell" -Recurse -Force -ErrorAction SilentlyContinue |
+# Collect all paths under repository root
+$structure = Get-ChildItem -Path $repoRoot -Recurse -Force -ErrorAction SilentlyContinue |
     Select-Object -ExpandProperty FullName | Sort-Object
 
 # Format paths into a visual tree

--- a/Tools/AgentChatController_20250519_121655.ps1
+++ b/Tools/AgentChatController_20250519_121655.ps1
@@ -4,7 +4,8 @@
 # Requires: .env with OPENAI_API_KEY and GROK_API_KEY
 # ========================================
 
-$envPath = "X:\AICommandCenter\PowerShell\Config\.env"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$envPath   = Join-Path $scriptRoot '..\Config\.env'
 
 # === Load API keys from .env file ===
 if (-not (Test-Path $envPath)) {

--- a/Tools/Load-Env.ps1
+++ b/Tools/Load-Env.ps1
@@ -1,7 +1,11 @@
+
 # =====================================
 # Load-Env.ps1 — Import .env to $env:
 # =====================================
-$envFile = "X:\AICommandCenter\PowerShell\Config\.env"
+
+# Determine repository root relative to this script
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$envFile = Join-Path $scriptRoot '..\Config\.env'
 
 if (-not (Test-Path $envFile)) {
     Write-Error "❌ .env file not found: $envFile"

--- a/Tools/SessionLogger.ps1
+++ b/Tools/SessionLogger.ps1
@@ -1,8 +1,9 @@
 # SessionLogger.ps1 — Logs PowerShell version and session start
 
-# Define proper log location
-$logRoot = "X:\AICommandCenter\PowerShell\Logs"
-$logFile = "$logRoot\SessionLog.csv"
+# Determine repository root relative to this script
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$logRoot = Join-Path $scriptRoot '..\Logs'
+$logFile = Join-Path $logRoot 'SessionLog.csv'
 
 # Ensure directory exists
 if (-not (Test-Path $logRoot)) {

--- a/Tools/Start-HeadlessBrowser.ps1
+++ b/Tools/Start-HeadlessBrowser.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$Url = "https://example.com",
+    [switch]$Edge
+)
+
+# Determine which browser to use
+if ($Edge) {
+    $browser = "msedge"
+} else {
+    $browser = "chrome"
+}
+
+# Build start info with headless flags
+$arguments = "--headless=new --disable-gpu --window-size=1280,800 $Url"
+
+try {
+    Start-Process -FilePath $browser -ArgumentList $arguments
+    Write-Host "✅ Launched $browser in headless mode." -ForegroundColor Green
+} catch {
+    Write-Error "❌ Failed to launch $browser: $($_.Exception.Message)"
+}

--- a/Tools/Whisper/Transcribe-Audio.ps1
+++ b/Tools/Whisper/Transcribe-Audio.ps1
@@ -3,9 +3,10 @@ param (
     [string]$SourceUrl
 )
 
-# Default input/output folders
-$defaultInputDir = "X:\AICommandCenter\PowerShell\Data\RawAudio"
-$transcriptDir = "X:\AICommandCenter\PowerShell\Data\Transcripts"
+# Determine repository root relative to this script
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$defaultInputDir = Join-Path $scriptRoot '..\Data\RawAudio'
+$transcriptDir   = Join-Path $scriptRoot '..\Data\Transcripts'
 
 # Create required folders if missing
 foreach ($dir in @($defaultInputDir, $transcriptDir)) {


### PR DESCRIPTION
## Summary
- load environment variables and utilities from profile at startup
- resolve repository paths dynamically in scripts
- add example `.env` file
- add headless browser launcher
- document usage of profile and headless browser

## Testing
- `pwsh -NoProfile -File Tools/SessionLogger.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b74c59f9083308b25c69a7de27109