### PR TITLE
Improve headless browser script detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository collects various PowerShell tools and modules used for working w
    ```bash
    pip install openai-whisper
    ```
-3. Optionally clone the Grok SDK if you plan to use Grok:
+3. **Chrome or Edge** – required for `Start-HeadlessBrowser.ps1`. The script checks
+   common install locations based on your OS. Use `-BrowserPath` if it cannot find the executable.
+4. Optionally clone the Grok SDK if you plan to use Grok:
    ```bash
    git clone https://github.com/xai-org/grok.git KnowledgeBase/GrokAI/grok-sdk
    ```
@@ -53,7 +55,9 @@ Run `Tools/Load-Env.ps1` to import the variables into the current PowerShell ses
   ```powershell
   ./Tools/SessionLogger.ps1
   ```
-- **Start-HeadlessBrowser.ps1** – Launches Chrome or Edge in headless mode:
+- **Start-HeadlessBrowser.ps1** – Launches Chrome or Edge in headless mode. The
+  script verifies the browser executable based on your OS. Provide a custom path
+  with `-BrowserPath` if needed:
   ```powershell
   ./Tools/Start-HeadlessBrowser.ps1 -Url "https://example.com" -Edge
   ```

--- a/Tools/Start-HeadlessBrowser.ps1
+++ b/Tools/Start-HeadlessBrowser.ps1
@@ -1,21 +1,56 @@
+# ======================================
+# Start-HeadlessBrowser.ps1 — Cross-platform launcher
+# ======================================
+
 param(
     [string]$Url = "https://example.com",
-    [switch]$Edge
+    [switch]$Edge,
+    [string]$BrowserPath
 )
 
 # Determine which browser to use
-if ($Edge) {
-    $browser = "msedge"
-} else {
-    $browser = "chrome"
+$browser = if ($Edge) { "msedge" } else { "chrome" }
+
+# Build candidate paths based on OS
+$candidates = @()
+if ($BrowserPath) {
+    $candidates += $BrowserPath
+}
+
+# Look for executable in PATH first
+$command = Get-Command $browser -ErrorAction SilentlyContinue
+if ($command) { $candidates += $command.Source }
+
+if ($IsWindows) {
+    if ($browser -eq "msedge") {
+        $candidates += "$env:ProgramFiles\Microsoft\Edge\Application\msedge.exe"
+        $candidates += "$env:ProgramFiles(x86)\Microsoft\Edge\Application\msedge.exe"
+    } else {
+        $candidates += "$env:ProgramFiles\Google\Chrome\Application\chrome.exe"
+        $candidates += "$env:ProgramFiles(x86)\Google\Chrome\Application\chrome.exe"
+    }
+} elseif ($IsMacOS) {
+    if ($browser -eq "msedge") {
+        $candidates += '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+    } else {
+        $candidates += '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+    }
+}
+
+# Select the first valid path
+$browserExe = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+if (-not $browserExe) {
+    Write-Error "❌ $browser executable not found. Specify a path with -BrowserPath."
+    return
 }
 
 # Build start info with headless flags
 $arguments = "--headless=new --disable-gpu --window-size=1280,800 $Url"
 
 try {
-    Start-Process -FilePath $browser -ArgumentList $arguments
-    Write-Host "✅ Launched $browser in headless mode." -ForegroundColor Green
+    Start-Process -FilePath $browserExe -ArgumentList $arguments
+    Write-Host "✅ Launched $browserExe in headless mode." -ForegroundColor Green
 } catch {
-    Write-Error "❌ Failed to launch $browser: $($_.Exception.Message)"
+    Write-Error "❌ Failed to launch $browserExe: $($_.Exception.Message)"
 }


### PR DESCRIPTION
## Summary
- add OS-aware browser discovery logic
- allow specifying a custom browser path
- document browser requirement in the README

## Testing
- `pwsh -c "Get-Help"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b7deeab2c8330aa591f81dcb434e7