### PR TITLE
Fix variable parsing in Start-HeadlessBrowser.ps1

### DIFF
--- a/Tools/Start-HeadlessBrowser.ps1
+++ b/Tools/Start-HeadlessBrowser.ps1
@@ -52,5 +52,5 @@ try {
     Start-Process -FilePath $browserExe -ArgumentList $arguments
     Write-Host "✅ Launched $browserExe in headless mode." -ForegroundColor Green
 } catch {
-    Write-Error "❌ Failed to launch $browserExe: $($_.Exception.Message)"
+    Write-Error "❌ Failed to launch ${browserExe}: $($_.Exception.Message)"
 }


### PR DESCRIPTION
## Summary
- correct variable syntax in `Start-HeadlessBrowser.ps1`

## Testing
- `pwsh -NoProfile -File Tools/Start-HeadlessBrowser.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b8390c04083308abd7a4b531618db